### PR TITLE
over hele boken: Bruk NVIDIA med store bokstaver

### DIFF
--- a/multimedia/libdriv/libvdpau.xml
+++ b/multimedia/libdriv/libvdpau.xml
@@ -37,7 +37,7 @@
 
       <para>
         VDPAU (Video Decode and Presentation API for Unix) er et åpen kildekode
-        bibliotek (libvdpau) og API opprinnelig designet av Nvidia for GeForce
+        bibliotek (libvdpau) og API opprinnelig designet av NVIDIA for GeForce
         8 serien og senere GPU maskinvare rettet mot X vindussytemet.
         Denne VDPAU API lar videoprogrammer laste ned deler av videoen
         dekodingsprosess og videoetterbehandling til GPU videomaskinvaren.
@@ -52,7 +52,7 @@
         GPU avhenger av versjonen av GPU maskinvaren; nærmere bestemt,
         for også å dekode MPEG-4 ASP (MPEG-4 del 2), Xvid/OpenDivX (DivX 4), og
         DivX 5-formater, en GeForce 200M (2xxM) Series (den ellevte generasjon av
-        Nvidias GeForce grafikkbehandlingsenheter) eller nyere GPU maskinvare er
+        NVIDIA sin GeForce grafikkbehandlingsenheter) eller nyere GPU maskinvare er
         nødvendig.
       </para>
 

--- a/postlfs/config/firmware.xml
+++ b/postlfs/config/firmware.xml
@@ -93,7 +93,7 @@
       <para>
         Firmware for videokontrollere. På x86-maskiner kreves dette for
         ATI-enheter (Radeon- og AMDGPU-brikker) og kan være nyttige for Intel (Skylake
-        og senere) og Nvidia (Kepler og senere) GPUer.
+        og senere) og NVIDIA (Kepler og senere) GPUer.
       </para>
 
       <para>
@@ -116,8 +116,8 @@
       </para>
 
       <para>
-        Nvidia GPUer fra Kepler og utover krever signert fastvare, ellers er
-        nouveau-driveren ikke i stand til å gi maskinvareakselerasjon. Nvidia har
+        NVIDIA GPUer fra Kepler og utover krever signert fastvare, ellers er
+        nouveau-driveren ikke i stand til å gi maskinvareakselerasjon. NVIDIA har
         nå utgitt firmware opp til Ada Lovelace (GeForce 40 series) til
         linux-firmware.
       </para>
@@ -572,10 +572,10 @@ cp -v &lt;YOUR_BLOBS&gt; /usr/lib/firmware/amdgpu</userinput></screen>
     </sect3>
 
     <sect3 id="nvidia-video-firmware">
-      <title>Fastvare for Nvidia videobrikker</title>
+      <title>Fastvare for NVIDIA videobrikker</title>
 
       <para>
-        Nvidia har gitt ut grunnleggende signert fastvare for nyere grafikkbrikker,
+        NVIDIA har gitt ut grunnleggende signert fastvare for nyere grafikkbrikker,
         men betydelig etter at chipene og dens egne binære drivere var først
         tilgjengelig. For andre brikker har det vært nødvendig å trekke ut fastvaren
         fra den binære driveren.

--- a/x/installing/mesa.xml
+++ b/x/installing/mesa.xml
@@ -181,7 +181,7 @@
 
       <para>
         Videoenheten er mest sannsynlig en av tre familier: AMD, Intel eller
-        Nvidia. Se parameterforklaringene for
+        NVIDIA. Se parameterforklaringene for
         <parameter>-D gallium-drivers=auto</parameter> nedenfor for å
         se hvilke alternativer som er tilgjengelige for din spesifikke videomaskinvare (eller
         emulert videomaskinvare). Du bør sannsynligvis legge til softpipe eller

--- a/xsoft/graphweb/firefox.xml
+++ b/xsoft/graphweb/firefox.xml
@@ -615,7 +615,7 @@ ln -sfv /usr/lib/firefox/browser/chrome/icons/default/default128.png \
 
       <para>
         Selv om WebRender (bruker GPU for komposisjon) ikke brukes av
-        standard, ser det nå ut til å fungere bra på støttet maskinvare (ATI, Nvidia
+        standard, ser det nå ut til å fungere bra på støttet maskinvare (ATI, NVIDIA
         og Intel GPUer med Mesa-18 eller nyere). For en forklaring, se
         <ulink
        url="https://hacks.mozilla.org/2017/10/the-whole-web-at-maximum-fps-how-webrender-gets-rid-of-jank/">hacks.mozilla.org</ulink>.


### PR DESCRIPTION
Det ser ut til at formen med store bokstaver brukes overalt (unntatt tittelen på den engelske Wikipedia-siden bruker "Nvidia," merk at sidens innhold bruker fortsatt "NVIDIA").